### PR TITLE
Minor tidy-ups to the general fix code

### DIFF
--- a/lib/convert-worker.js
+++ b/lib/convert-worker.js
@@ -1046,7 +1046,7 @@ function standardizeSpellings(xml) {
   xml = xml.replace(/(C|c)ounsell/vg, "$1ounsel");
 
   // Clich(e|é) is spelled both ways. Let's standardize on including the accent.
-  xml = xml.replace(/cliche/vg, "cliché");
+  xml = xml.replace(/(C|c)liche/vg, "$1liché");
 
   // T-shirt is usually spelled lowercase ("t-shirt"). Normalize the remaining instances.
   xml = xml.replace(/(?<! {2})T-shirt/vg, "t-shirt");
@@ -1072,7 +1072,7 @@ function standardizeSpellings(xml) {
   xml = xml.replace(/Jeez/vg, "Geez");
 
   // 10 instances of "eye shadow" to 7 of "eyeshadow"; dictionaries prefer the former.
-  xml = xml.replace(/eyeshadow/vg, "eye shadow");
+  xml = xml.replace(/(E|e)yeshadow/vg, "$1ye shadow");
 
   // 3 instances of "spacial" to 10 of "spatial"
   xml = xml.replace(/(S|s)pacial/vg, "$1patial");
@@ -1123,8 +1123,8 @@ function fixCaseNumbers(xml) {
   // nouns.
 
   xml = xml.replace(/case[ \-](?:fifty[ \-]three|53)(?!’)/vig, "Case Fifty-Three");
-  xml = xml.replace(/case[ \-](?:thirty[ \-]two|53)(?!’)/vig, "Case Thirty-Two");
-  xml = xml.replace(/case[ \-](?:sixty[ \-]nine|53)(?!’)/vig, "Case Sixty-Nine");
+  xml = xml.replace(/case[ \-](?:thirty[ \-]two|32)(?!’)/vig, "Case Thirty-Two");
+  xml = xml.replace(/case[ \-](?:sixty[ \-]nine|69)(?!’)/vig, "Case Sixty-Nine");
 
   xml = xml.replace(
     /(?<!in )case[ \-](zero|one|two|three|four|twelve|fifteen|seventy|ninety)(?!-)/vig,


### PR DESCRIPTION
Most of these have no effect as we're fixing "bugs" that never manifest on the actual texts. However, two instances of capitalized "Cliche" were previously missed and now converted to "Cliché", like what was already done for the lowercase spelling.